### PR TITLE
Place upper/lower bounds on Previous/Next links

### DIFF
--- a/VueSimplePagination.vue
+++ b/VueSimplePagination.vue
@@ -3,7 +3,7 @@
     <nav v-if="moreThanOnePage">
         <ul :class="ulClass">
             <li :class="getClass('previous')">
-                <a @click="setCurrentPage(currentPage-1)" aria-label="Previous">
+                <a @click="setCurrentPage(Math.max(1, currentPage - 1))" aria-label="Previous">
                     <span aria-hidden="true">&laquo;</span>
                 </a>
             </li>
@@ -11,7 +11,7 @@
                 {{ page.number }}</a><span v-if="pageNull(page)">...</span>
             </li>
             <li :class="getClass('next')">
-                <a @click="setCurrentPage(currentPage+1)" aria-label="Next">
+                <a @click="setCurrentPage(Math.min(pageCount, currentPage + 1))" aria-label="Next">
                     <span aria-hidden="true">&raquo;</span>
                 </a>
             </li>


### PR DESCRIPTION
Use `Math.max` and `Math.min` to ensure that the Previous and Next
hyperlinks do not lead to pages less than 1 or greater than `pageCount`
respectively